### PR TITLE
Switch the input numbering font to Source Code Pro

### DIFF
--- a/notebook.sketch
+++ b/notebook.sketch
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6f83afe0ea597338f9b50d5e1ab85737b2cd63df6cb5f2f3f7a614a9c750e497
-size 245760
+oid sha256:66be755a165ad5964896b4b3c7a6458e822b43208b6da9ef956672115e0fd55c
+size 188416


### PR DESCRIPTION
It was using Consolas for some reason, which is not an open source font
(Consolas is Microsoft's, comes from e.g. PowerPoint). Additionally, our actual UI uses Source Code Pro for the input numbering - this was likely an oversight from me from when I made these original sketches.